### PR TITLE
Add Freebox FTTH optical power sensors

### DIFF
--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -190,6 +190,13 @@ class FreeboxRouter:
         for sensor_key in CONNECTION_SENSORS_KEYS:
             self.sensors_connection[sensor_key] = connection_datas[sensor_key]
 
+        if connection_datas.get("media") == "ftth":
+            ftth_datas: dict[str, Any] = await self._api.connection.get_ftth()
+            if (sfp_pwr_rx := ftth_datas.get("sfp_pwr_rx")) is not None:
+                self.sensors_connection["sfp_pwr_rx"] = sfp_pwr_rx / 100
+            if (sfp_pwr_tx := ftth_datas.get("sfp_pwr_tx")) is not None:
+                self.sensors_connection["sfp_pwr_tx"] = sfp_pwr_tx / 100
+
         self._attrs = {
             "IPv4": connection_datas.get("ipv4"),
             "IPv6": connection_datas.get("ipv6"),

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -55,6 +55,7 @@ FTTH_SENSORS: tuple[SensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        suggested_display_precision=2,
         icon="mdi:arrow-down",
     ),
     SensorEntityDescription(
@@ -63,6 +64,7 @@ FTTH_SENSORS: tuple[SensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        suggested_display_precision=2,
         icon="mdi:arrow-up",
     ),
 )
@@ -118,7 +120,7 @@ async def async_setup_entry(
         [FreeboxSensor(router, description) for description in CONNECTION_SENSORS]
     )
     entities.extend(
-        FreeboxSensor(router, description)
+        FreeboxFtthSensor(router, description)
         for description in FTTH_SENSORS
         if description.key in router.sensors_connection
     )
@@ -186,6 +188,15 @@ class FreeboxSensor(SensorEntity):
                 self.async_on_demand_update,
             )
         )
+
+
+class FreeboxFtthSensor(FreeboxSensor):
+    """Representation of a Freebox FTTH sensor."""
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return FTTH attributes."""
+        return self._router.ftth_info
 
 
 class FreeboxCallSensor(FreeboxSensor):

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -11,7 +11,12 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, UnitOfDataRate, UnitOfTemperature
+from homeassistant.const import (
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    UnitOfDataRate,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -40,6 +45,25 @@ CONNECTION_SENSORS: tuple[SensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfDataRate.KILOBYTES_PER_SECOND,
         icon="mdi:upload-network",
+    ),
+)
+
+FTTH_SENSORS: tuple[SensorEntityDescription, ...] = (
+    SensorEntityDescription(
+        key="sfp_pwr_rx",
+        name="Freebox SFP RX power",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        icon="mdi:arrow-down",
+    ),
+    SensorEntityDescription(
+        key="sfp_pwr_tx",
+        name="Freebox SFP TX power",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        icon="mdi:arrow-up",
     ),
 )
 
@@ -92,6 +116,11 @@ async def async_setup_entry(
 
     entities.extend(
         [FreeboxSensor(router, description) for description in CONNECTION_SENSORS]
+    )
+    entities.extend(
+        FreeboxSensor(router, description)
+        for description in FTTH_SENSORS
+        if description.key in router.sensors_connection
     )
     entities.extend(
         [FreeboxCallSensor(router, description) for description in CALL_SENSORS]

--- a/tests/components/freebox/conftest.py
+++ b/tests/components/freebox/conftest.py
@@ -11,6 +11,7 @@ from homeassistant.helpers import device_registry as dr
 
 from .const import (
     DATA_CALL_GET_CALLS_LOG,
+    DATA_CONNECTION_GET_FTTH,
     DATA_CONNECTION_GET_STATUS,
     DATA_HOME_GET_NODES,
     DATA_HOME_PIR_GET_VALUE,
@@ -83,6 +84,7 @@ def mock_router(mock_device_registry_devices):
         instance.connection.get_status = AsyncMock(
             return_value=DATA_CONNECTION_GET_STATUS
         )
+        instance.connection.get_ftth = AsyncMock(return_value=DATA_CONNECTION_GET_FTTH)
         # switch
         instance.wifi.get_global_config = AsyncMock(
             return_value=DATA_WIFI_GET_GLOBAL_CONFIG

--- a/tests/components/freebox/const.py
+++ b/tests/components/freebox/const.py
@@ -13,6 +13,8 @@ DATA_CONNECTION_GET_STATUS = load_json_object_fixture(
     "freebox/connection_get_status.json"
 )
 
+DATA_CONNECTION_GET_FTTH = load_json_object_fixture("freebox/connection_get_ftth.json")
+
 DATA_CALL_GET_CALLS_LOG = load_json_array_fixture("freebox/call_get_calls_log.json")
 
 DATA_STORAGE_GET_DISKS = load_json_array_fixture("freebox/storage_get_disks.json")

--- a/tests/components/freebox/fixtures/connection_get_ftth.json
+++ b/tests/components/freebox/fixtures/connection_get_ftth.json
@@ -1,0 +1,12 @@
+{
+  "sfp_present": true,
+  "sfp_alim_ok": true,
+  "sfp_has_power_report": true,
+  "sfp_has_signal": true,
+  "link": true,
+  "sfp_serial": "ABC123",
+  "sfp_model": "GPON SFP",
+  "sfp_vendor": "Freebox",
+  "sfp_pwr_tx": -366,
+  "sfp_pwr_rx": -2225
+}

--- a/tests/components/freebox/test_sensor.py
+++ b/tests/components/freebox/test_sensor.py
@@ -42,6 +42,14 @@ async def test_network_speed(
     assert hass.states.get("sensor.freebox_upload_speed").state == "432.1"
 
 
+async def test_ftth_power(hass: HomeAssistant, router: Mock) -> None:
+    """Test FTTH optical power sensors."""
+    await setup_platform(hass, SENSOR_DOMAIN)
+
+    assert hass.states.get("sensor.freebox_sfp_rx_power").state == "-22.25"
+    assert hass.states.get("sensor.freebox_sfp_tx_power").state == "-3.66"
+
+
 async def test_call(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, router: Mock
 ) -> None:

--- a/tests/components/freebox/test_sensor.py
+++ b/tests/components/freebox/test_sensor.py
@@ -46,8 +46,24 @@ async def test_ftth_power(hass: HomeAssistant, router: Mock) -> None:
     """Test FTTH optical power sensors."""
     await setup_platform(hass, SENSOR_DOMAIN)
 
-    assert hass.states.get("sensor.freebox_sfp_rx_power").state == "-22.25"
-    assert hass.states.get("sensor.freebox_sfp_tx_power").state == "-3.66"
+    state_rx = hass.states.get("sensor.freebox_sfp_rx_power")
+    state_tx = hass.states.get("sensor.freebox_sfp_tx_power")
+
+    assert state_rx.state == "-22.25"
+    assert state_tx.state == "-3.66"
+    assert state_rx.attributes["sfp_model"] == "GPON SFP"
+    assert state_rx.attributes["sfp_vendor"] == "Freebox"
+
+
+async def test_no_ftth_media(hass: HomeAssistant, router: Mock) -> None:
+    """Test that FTTH sensors are not created when media is not FTTH."""
+    data_connection_get_status = deepcopy(DATA_CONNECTION_GET_STATUS)
+    data_connection_get_status["media"] = "dsl"
+    router().connection.get_status.return_value = data_connection_get_status
+    await setup_platform(hass, SENSOR_DOMAIN)
+
+    assert hass.states.get("sensor.freebox_sfp_rx_power") is None
+    assert hass.states.get("sensor.freebox_sfp_tx_power") is None
 
 
 async def test_call(


### PR DESCRIPTION
## Summary
- expose Freebox SFP RX/TX optical power as sensors
- add test coverage and fixture for FTTH values

## Testing
- `pre-commit run --files homeassistant/components/freebox/router.py homeassistant/components/freebox/sensor.py tests/components/freebox/conftest.py tests/components/freebox/const.py tests/components/freebox/test_sensor.py tests/components/freebox/fixtures/connection_get_ftth.json` *(fails: mypy requires Python 3.13, pylint option error)*
- `pytest tests/components/freebox/test_sensor.py` *(fails: SyntaxError: invalid syntax in homeassistant/util/event_type.py)*

------
https://chatgpt.com/codex/tasks/task_e_688e441054b8832fb47c6578e04cd1b2